### PR TITLE
GOCI-2277: Change how reporting scripts query for each job's run time

### DIFF
--- a/bin/failure/find_errors_in_load.lsf
+++ b/bin/failure/find_errors_in_load.lsf
@@ -32,7 +32,7 @@ function act_on_error(){
 
 function log_load_complete(){
     num_lines=$(wc -l $base/files/toload/$input_file |  cut -d" " -f1)
-    run_time=$(grep "Run time" $job_output | cut -d":" -f2 | tr -d '[:space:]')
+    run_time=$(grep "CPU time" $job_output | cut -d":" -f2 | tr -d '[:space:]')
     max_mem=$(grep "Max Memory" $job_output | cut -d":" -f2 | tr -d '[:space:]')
     max_swap=$(grep "Max Swap" $job_output | cut -d":" -f2 | tr -d '[:space:]')
     disk_space=$(du -h "$output_loc"/"$load_type_dir"/"$h5file" | cut -f1)

--- a/query_stats/query_metrics.lsf
+++ b/query_stats/query_metrics.lsf
@@ -19,7 +19,7 @@ if [ -z $log ]; then
 fi
 
 
-run_time=$(grep "Run time" $file | cut -d":" -f2 | tr -d '[:space:]')
+run_time=$(grep "CPU time" $file | cut -d":" -f2 | tr -d '[:space:]')
 max_mem=$(grep "Max Memory" $file | cut -d":" -f2 | tr -d '[:space:]')
 
 echo "$run_time" | sed 's/\./ /g' >> "$log"_time


### PR DESCRIPTION
Please merge into master as soon as possible (no loading should be running).

Generated reports are not recording the run time of the studies that are being loaded.
